### PR TITLE
[Feature] Add php-bz2 and bzip2-dev as dependencies

### DIFF
--- a/1.10.5/php7.2/Dockerfile
+++ b/1.10.5/php7.2/Dockerfile
@@ -22,6 +22,7 @@ RUN set -eux; \
     icu-dev \
     gettext-dev \
     libsodium-dev \
+    bzip2-dev \
   ; \
   docker-php-ext-install -j "$(nproc)" \
     opcache \
@@ -32,6 +33,7 @@ RUN set -eux; \
     gettext \
     mysqli \
     pdo_mysql \
+    bz2 \
   ; \
   docker-php-ext-enable \
     opcache \
@@ -42,6 +44,7 @@ RUN set -eux; \
     gettext \
     mysqli \
     pdo_mysql \
+    bz2 \
   ; \
   runDeps="$( \
     scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \

--- a/1.10.5/php7.3/Dockerfile
+++ b/1.10.5/php7.3/Dockerfile
@@ -22,6 +22,7 @@ RUN set -eux; \
     icu-dev \
     gettext-dev \
     libsodium-dev \
+    bzip2-dev \
   ; \
   docker-php-ext-install -j "$(nproc)" \
     opcache \
@@ -32,6 +33,7 @@ RUN set -eux; \
     gettext \
     mysqli \
     pdo_mysql \
+    bz2 \
   ; \
   docker-php-ext-enable \
     opcache \
@@ -42,6 +44,7 @@ RUN set -eux; \
     gettext \
     mysqli \
     pdo_mysql \
+    bz2 \
   ; \
   runDeps="$( \
     scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \

--- a/1.10.5/php7.4/Dockerfile
+++ b/1.10.5/php7.4/Dockerfile
@@ -22,6 +22,7 @@ RUN set -eux; \
     icu-dev \
     gettext-dev \
     libsodium-dev \
+    bzip2-dev \
   ; \
   docker-php-ext-install -j "$(nproc)" \
     opcache \
@@ -32,6 +33,7 @@ RUN set -eux; \
     gettext \
     mysqli \
     pdo_mysql \
+    bz2 \
   ; \
   docker-php-ext-enable \
     opcache \
@@ -42,6 +44,7 @@ RUN set -eux; \
     gettext \
     mysqli \
     pdo_mysql \
+    bz2 \
   ; \
   runDeps="$( \
     scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \

--- a/1.9.3/php7.2/Dockerfile
+++ b/1.9.3/php7.2/Dockerfile
@@ -22,6 +22,7 @@ RUN set -eux; \
     icu-dev \
     gettext-dev \
     libsodium-dev \
+    bzip2-dev \
   ; \
   docker-php-ext-install -j "$(nproc)" \
     opcache \
@@ -32,6 +33,7 @@ RUN set -eux; \
     gettext \
     mysqli \
     pdo_mysql \
+    bz2 \
   ; \
   docker-php-ext-enable \
     opcache \
@@ -42,6 +44,7 @@ RUN set -eux; \
     gettext \
     mysqli \
     pdo_mysql \
+    bz2 \
   ; \
   runDeps="$( \
     scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \

--- a/1.9.3/php7.3/Dockerfile
+++ b/1.9.3/php7.3/Dockerfile
@@ -22,6 +22,7 @@ RUN set -eux; \
     icu-dev \
     gettext-dev \
     libsodium-dev \
+    bzip2-dev \
   ; \
   docker-php-ext-install -j "$(nproc)" \
     opcache \
@@ -32,6 +33,7 @@ RUN set -eux; \
     gettext \
     mysqli \
     pdo_mysql \
+    bz2 \
   ; \
   docker-php-ext-enable \
     opcache \
@@ -42,6 +44,7 @@ RUN set -eux; \
     gettext \
     mysqli \
     pdo_mysql \
+    bz2 \
   ; \
   runDeps="$( \
     scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \

--- a/1.9.3/php7.4/Dockerfile
+++ b/1.9.3/php7.4/Dockerfile
@@ -22,6 +22,7 @@ RUN set -eux; \
     icu-dev \
     gettext-dev \
     libsodium-dev \
+    bzip2-dev \
   ; \
   docker-php-ext-install -j "$(nproc)" \
     opcache \
@@ -32,6 +33,7 @@ RUN set -eux; \
     gettext \
     mysqli \
     pdo_mysql \
+    bz2 \
   ; \
   docker-php-ext-enable \
     opcache \
@@ -42,6 +44,7 @@ RUN set -eux; \
     gettext \
     mysqli \
     pdo_mysql \
+    bz2 \
   ; \
   runDeps="$( \
     scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \


### PR DESCRIPTION
# Feature
## Add php-bz2 and bzip2-dev as dependencies

### Synopsis
php-bz2 is not added by default and is a requirement to composer (depending on the machine you are running). 

### Usage
No additional usage is required.

### To-Dos:

- [ ] Test docker in dev-environment

### Disclaimer:
I'm unable to test with my setup at the moment. Please validate this and, if this works as intended, merge.